### PR TITLE
Update streamdeck when preview scene is changed

### DIFF
--- a/streamdeckplugin_module.cpp
+++ b/streamdeckplugin_module.cpp
@@ -376,7 +376,19 @@ void OBSEvent(enum obs_frontend_event event, void* data)
 			}
 		}
 		break;
-		
+
+		case OBS_FRONTEND_EVENT_PREVIEW_SCENE_CHANGED:
+		{
+			qDebug() << "OBS_FRONTEND_EVENT_PREVIEW_SCENE_CHANGED";
+
+			if (actionHelpPtr
+				&& actionHelpPtr->GetIsRespondingCollectionsSchemaFlag())
+			{
+				QMetaObject::invokeMethod(actionHelpPtr, "NotifySceneSwitched");
+			}
+		}
+		break;
+
 		case OBS_FRONTEND_EVENT_SCENE_LIST_CHANGED:
 		{
 			qDebug() << "OBS_FRONTEND_EVENT_SCENE_LIST_CHANGED";


### PR DESCRIPTION
Right now changing the studio mode preview scene externally (using OBS, websocket, etc.) doesn't update the streamdeck.

This was tested with OBS 24.0.1 on Windows