### PR TITLE
Only connect to item_visible handler for group sources

### DIFF
--- a/streamdeckplugin_module.cpp
+++ b/streamdeckplugin_module.cpp
@@ -170,29 +170,18 @@ void UpdateScenes()
 		for (int j = 0; j < srcInfo.sceneItems.count(); j++)
 		{
 			SceneItemInfo sceneItemInfo = srcInfo.sceneItems.at(j);
-
-			for (int k = 0; k < sceneItemInfo.groupSceneItems.count(); k++)
+			if(sceneItemInfo.isGroup)
 			{
-				GroupItemInfo groupItemInfo = sceneItemInfo.groupSceneItems.at(k);
-				auto source = obs_sceneitem_get_source(groupItemInfo.item);
-				signal_handler_t* groupItemSignalHandler = obs_source_get_signal_handler(source);
 
-				if (groupItemSignalHandler == NULL)
+				signal_handler_t* sceneItemSignalHandler = obs_source_get_signal_handler(sceneItemInfo.source);
+
+				if (sceneItemSignalHandler == NULL)
 				{
 					continue;
 				}
 
-				signal_handler_connect(groupItemSignalHandler, "item_visible", ItemVisible, nullptr);
+				signal_handler_connect(sceneItemSignalHandler, "item_visible", ItemVisible, nullptr);
 			}
-
-			signal_handler_t* sceneItemSignalHandler = obs_source_get_signal_handler(sceneItemInfo.source);
-
-			if (sceneItemSignalHandler == NULL)
-			{
-				continue;
-			}
-
-			signal_handler_connect(sceneItemSignalHandler, "item_visible", ItemVisible, nullptr);
 		}
 
 		signal_handler_t* signalHandler = obs_source_get_signal_handler(srcInfo.scene);


### PR DESCRIPTION
Most sources don't have the item_visible signal, only groups ans scenes support the item_visible signal.
Trying to connect to a signal that not exists creates warning log records in OBS which makes the application slower and the log less readable.
See documentation:
https://obsproject.com/docs/reference-scenes.html#scene-signals
https://obsproject.com/docs/reference-sources.html#source-signals
